### PR TITLE
修改register时的添加订阅者方法的逻辑

### DIFF
--- a/rxbuslibrary/src/main/java/com/wzgiceman/rxbuslibrary/rxbus/RxBus.java
+++ b/rxbuslibrary/src/main/java/com/wzgiceman/rxbuslibrary/rxbus/RxBus.java
@@ -163,9 +163,9 @@ public class RxBus {
                             sticky);
 
                     if (isAdd(eventType, subscriberMethod)) {
-                        addSubscriber(subscriberMethod);
+                        addSubscriberToMap(eventType, subscriberMethod); 
                     }
-                    addSubscriberToMap(eventType, subscriberMethod);
+                    addSubscriber(subscriberMethod);
                 }
             }
         }


### PR DESCRIPTION
当isAdd()返回true时，表示该subscriberMethod未添加到map中，所以应该先调用addSubscriberToMap，然后在addSubscriber方法中，去添加该订阅者后的回调中，才能从map中取到该subscriberMethod对象，才能正常的反射调用，否则，会因为在map中娶不到该subscriberMethod对象而不走反射的逻辑，而无法成功接收订阅